### PR TITLE
Support Windows path system which contains backslashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const mix = require("laravel-mix");
 
 const escapeRegExp = (str) => str.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+const slashPattern = '[/\\\\]';
 
 /**
  * Babel-transpile dependencies inside `node_modules`
@@ -76,7 +77,7 @@ class TranspileNodeModules {
       return /node_modules/;
     } else {
       const includeModules = transpile.map(escapeRegExp).join("|");
-      return new RegExp(`node_modules/(?!(${includeModules})/)`);
+      return new RegExp(`node_modules${slashPattern}(?!(${includeModules})${slashPattern})`);
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const mix = require("laravel-mix");
 const path = require('path');
 
 const escapeRegExp = (str) => str.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
-const slashPatterh = `\\${path.sep}`;
+const slashPattern = `\\${path.sep}`;
 
 /**
  * Babel-transpile dependencies inside `node_modules`

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 const mix = require("laravel-mix");
+const path = require('path');
 
 const escapeRegExp = (str) => str.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
-const slashPattern = '[/\\\\]';
+const slashPatterh = `\\${path.sep}`;
 
 /**
  * Babel-transpile dependencies inside `node_modules`


### PR DESCRIPTION
_As a developer, I want to be able to use this module in both Windows and Unix OS and have the same behavior on each of these OS._

Currently, the RegExp defined when transpiling specific modules was only supporting regular slashes, but broke the build process on Windows. This pull request offers the support for both regular and back slashes.

I do not consider this as a new feature, nor as a breaking change. It could be part of a patch version release IMO.

Thank you BTW for offering this plugin!