### PR TITLE
Fix babel loader detector

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ class TranspileNodeModules {
   }
 
   ruleUsesBabel({ use }) {
-    return use && use.find(({ loader }) => loader === "babel-loader");
+    return use && use.find(({ loader }) => loader.includes("babel-loader"));
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ class TranspileNodeModules {
   }
 
   ruleUsesBabel({ use }) {
-    return use && use.find(({ loader }) => loader.includes("babel-loader"));
+    return use && use.find(({ loader }) => loader.match(/(^|\/)babel-loader(\/|$)/));
   }
 
   /**


### PR DESCRIPTION
For some reason mix is generating rule with full path to babel loader for me, like this:
```
loader: '_____full path goes here_____/node_modules/babel-loader/lib/index.js',
```